### PR TITLE
Hooks and notifications

### DIFF
--- a/Moderation.php
+++ b/Moderation.php
@@ -119,3 +119,12 @@ $wgModerationTimeToOverrideRejection = 2 * 7 * 24 * 3600; # 2 weeks
 # Keep this option at 'false' unless you know you need this.
 
 $wgModerationPreviewLink = false;
+
+# Administrator notification settings
+# $wgModerationNotificationEnable - enable or disable notifications
+# $wgModerationNotificationNewOnly - notify administrator only about new pages requests
+# $wgModerationEmail - email to send notifications
+
+$wgModerationNotificationEnable = false;
+$wgModerationNotificationNewOnly = false;
+$wgModerationEmail = $wgEmergencyContact;

--- a/action/ModerationActionShow.php
+++ b/action/ModerationActionShow.php
@@ -136,6 +136,35 @@ class ModerationActionShow extends ModerationAction {
 			$header_before = wfMessage('moderation-diff-header-before')->text();
 			$header_after = wfMessage('moderation-diff-header-after')->text();
 			$out->addHTML($de->addHeader($diff, $header_before, $header_after));
+
+			$approveLink = Linker::link(
+				$this->getSpecial()->getPageTitle(),
+				wfMessage('moderation-approve')->escaped(),
+				array( 'title' => wfMessage('tooltip-moderation-approve')->escaped() ),
+				array(
+					'modaction' => 'approve',
+					'modid' => $this->id,
+					'token' => $this->getSpecial()->getUser()->getEditToken($this->id)
+				),
+				array('known', 'noclasses')
+			);
+
+			$rejectLink = Linker::link(
+				$this->getSpecial()->getPageTitle(),
+				wfMessage('moderation-reject')->escaped(),
+				array( 'title' => wfMessage('tooltip-moderation-reject')->escaped() ),
+				array(
+					'modaction' => 'reject',
+					'modid' => $this->id,
+					'token' => $this->getSpecial()->getUser()->getEditToken($this->id)
+				),
+				array('known', 'noclasses')
+			);
+
+			$out->addHTML( $approveLink );
+			$out->addHTML(' / ');
+			$out->addHTML( $rejectLink );
+
 		}
 		else
 		{

--- a/extension.json
+++ b/extension.json
@@ -127,7 +127,9 @@
 	"config": {
 		"ModerationEnable": true,
 		"ModerationTimeToOverrideRejection": 1209600,
-		"ModerationPreviewLink": false
+		"ModerationPreviewLink": false,
+		"ModerationNotificationEnable": false,
+		"ModerationEmail": ""
 	},
 	"manifest_version": 1
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -93,5 +93,7 @@
 	"tooltip-moderation-reject": "Reject this single edit",
 	"tooltip-moderation-rejected-change": "View the rejected edit",
 	"tooltip-moderation-show": "View proposed changes",
-	"tooltip-moderation-unblock": "No longer send edits of this user to Spam folder"
+	"tooltip-moderation-unblock": "No longer send edits of this user to Spam folder",
+	"moderation-notification-subject": "[Moderation] Incoming change pending",
+	"moderation-notification-content": "New change pending for page '$1' from user '$2' , click to see: $3"
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -93,5 +93,7 @@
 	"tooltip-moderation-reject": "Отклонить эту правку",
 	"tooltip-moderation-rejected-change": "Просмотреть отклонённую правку",
 	"tooltip-moderation-show": "Посмотреть предлагаемые изменения",
-	"tooltip-moderation-unblock": "Более не отправлять правки этого участника в папку Спам"
+	"tooltip-moderation-unblock": "Более не отправлять правки этого участника в папку Спам",
+	"moderation-notification-subject": "[Модерация] Новое изменение ожидает проверки",
+	"moderation-notification-content": "Изменение страницы '$1' пользователем '$2' ожидает проверки, подробнее: $3"
 }


### PR DESCRIPTION
+ 'Moderation' hook to allow other extensions intercept moderation
workflow
+ 'ModerationPending' hook to notify other extensions about pending
changes
+ Email notifications about pending changes
+ $wgModerationNotificationEnable
+ $wgModerationNotificationNewOnly
+ $wgModerationEmail
+ Added 'Approve' and 'Reject' link to ModerationShow action page