### PR TITLE
Fix compatibility with the latest VisualEditor

### DIFF
--- a/modules/visualeditor/preload.ve.js
+++ b/modules/visualeditor/preload.ve.js
@@ -19,17 +19,18 @@
 			api = new mw.Api();
 
 		/* Override requestPageData() method */
-		mw.libs.ve.targetLoader.requestPageData = function( pageName, oldid, targetName, modified ) {
+		mw.libs.ve.targetLoader.requestPageData = function ( mode, pageName, section, oldid, targetName, modified ) {
 
 			/*
 				useDefault() - call the original (unmodified) method from mw.libs.ve.
 				Example: return useDefault( "no change is awaiting moderation, so nothing to preload!" );
 			*/
+			var self = this;
 			function useDefault( reason ) {
 				console.log( "Moderation: not preloading: " + reason );
 
-				return oldRequestPageData.apply( this, [
-					pageName, oldid, targetName, modified
+				return oldRequestPageData.apply( self, [
+					mode, pageName, section, oldid, targetName, modified
 				] );
 			}
 


### PR DESCRIPTION
Recently installed a MediaWiki 1.28 with VisualEditor-REL1_28-93528b7 and needed to make these changes to make the Moderation extension works with the VisualEditor