### PR TITLE
Use DeferredUpdates::preventOpportunisticUpdates() instead of $wgCommandLineMode hacks in tests

### DIFF
--- a/tests/benchmarks/approveAll.php
+++ b/tests/benchmarks/approveAll.php
@@ -80,8 +80,8 @@ class BenchmarkApproveAll extends ModerationBenchmark {
 
 	public function doActualWork( $i ) {
 		// Prevent DeferredUpdates::tryOpportunisticExecute() from running updates immediately
-		global $wgCommandLineMode;
-		$wgCommandLineMode = false;
+		// @phan-suppress-next-line PhanUnusedVariable
+		$cleanup = DeferredUpdates::preventOpportunisticUpdates();
 
 		$html = $this->runSpecialModeration( [
 			'modaction' => 'approveall',
@@ -90,7 +90,6 @@ class BenchmarkApproveAll extends ModerationBenchmark {
 		] );
 
 		// Run the DeferredUpdates
-		$wgCommandLineMode = true;
 		DeferredUpdates::doUpdates();
 
 		Wikimedia\Assert\Assert::postcondition(


### PR DESCRIPTION
This method is available since MediaWiki 1.38 (commit https://github.com/wikimedia/mediawiki/commit/84f0876b8302cd7d7ec727b2ed5daa49b6bddcc5 / <https://gerrit.wikimedia.org/r/c/mediawiki/core/+/754117>), and allows disabling the immediate execution of DeferredUpdates in a much simpler way. We've made similar changes to tests in MediaWiki itself in <https://phabricator.wikimedia.org/T353247>, and we're planning to deprecate using $wgCommandLineMode for this.

I realize that you still support MediaWiki 1.35, so I don't mind it if you leave this open for a few months or years :) until you want to drop compatibility. (Although I'm only changing tests, so if you don't run them against older versions any more, perhaps this can be merged already.)

I didn't run the tests locally, but I hope this works. Feel free to make changes if I broke something.